### PR TITLE
Security fix log4shell - CVE-2021-44832

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>14</maven.compiler.source>
         <maven.compiler.target>14</maven.compiler.target>
-        <log4j2.version>2.16.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <logback.version>1.2.8</logback.version>
     </properties>
     <parent>


### PR DESCRIPTION
Simple Upgrade for log4j to `2.17.1` - [CVE-2021-44832](https://logging.apache.org/log4j/2.x/security.html)